### PR TITLE
Akhlak/adding recent keystore files to the login with keystore modal

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": false
+}

--- a/src/App.js
+++ b/src/App.js
@@ -66,7 +66,10 @@ const App = () => {
     let address;
     const version = loginInfo && loginInfo.version;
     if (version == null || packageJson.version !== version) {
-        localStorage.clear();
+        localStorage.removeItem("loginInfo");
+        localStorage.removeItem("keplrAddress");
+        localStorage.removeItem("encryptedMnemonic");
+        localStorage.removeItem("keyStoreOnUse");
         history.push('/');
     } else {
         address = loginInfo && loginInfo.address;
@@ -112,7 +115,10 @@ const App = () => {
     window.addEventListener('storage', () => {
         if (JSON.parse(localStorage.getItem(LOGIN_INFO)) === null){
             dispatch(userLogout());
-            localStorage.clear();
+            
+            localStorage.removeItem("loginInfo");
+            localStorage.removeItem("keplrAddress");
+            localStorage.removeItem("encryptedMnemonic");
             history.push('/');
             window.location.reload();
             if(loginInfo && loginInfo.loginMode==="ledger"){

--- a/src/assets/scss/index.css
+++ b/src/assets/scss/index.css
@@ -857,6 +857,10 @@ ul li em {
 .custom-file-section .file-upload input {
   height: 40px;
 }
+.custom-file.disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
 
 .password-field .password-field-container {
   position: relative;
@@ -1877,6 +1881,11 @@ ul li em {
   transform: rotate(180deg);
 }
 
+
+.advanced-wallet-accordion.disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
 .advanced-wallet-accordion .accordion-body {
   height: auto;
   max-height: 0px;

--- a/src/assets/scss/index.css
+++ b/src/assets/scss/index.css
@@ -1752,10 +1752,7 @@ ul li em {
 }
 .home-page.pageError .text-container {
   height: calc(100vh - 78px);
-  display: flex;
-  display: -webkit-flex;
-  justify-content: center;
-  align-content: center;
+  text-align: center;
 }
 .home-page.pageError .text-container h3 {
   color: #c2c2c2;

--- a/src/components/RouteNotFound.js
+++ b/src/components/RouteNotFound.js
@@ -1,11 +1,26 @@
 import React from "react";
-import {NavLink} from 'react-router-dom';
+import {NavLink, 
+    useHistory
+} from 'react-router-dom';
 import {Nav, Navbar} from "react-bootstrap";
 import logo from "../assets/images/footer_logo.svg";
 import {useTranslation} from "react-i18next";
+// import { useEffect } from "react";
 
 const RouteNotFound = () => {
     const {t} = useTranslation();
+
+    const history = useHistory();
+
+    const reloadApp = () => {
+        localStorage.removeItem("loginInfo");
+        localStorage.removeItem("keplrAddress");
+        localStorage.removeItem("encryptedMnemonic");
+        localStorage.removeItem("keyStoreOnUse");
+        history.push('/');
+        window.location.reload();
+    };
+    
     return (
         <div className="home-page pageError">
             <Navbar collapseOnSelect expand="lg" bg="dark" variant="dark">
@@ -31,6 +46,7 @@ const RouteNotFound = () => {
             </Navbar>
             <div className="text-container">
                 <h3>Page Not Found</h3>
+                <button className="button button-primary large" onClick={reloadApp}>Refresh App</button>
             </div>
         </div>
     );

--- a/src/constants/localStorage.js
+++ b/src/constants/localStorage.js
@@ -15,3 +15,5 @@ export const THEME = "theme";
 export const ACCOUNT_NUMBER = "accountNumber";
 export const LEDGER = "ledger";
 export const ADDRESS_INDEX = "addressIndex";
+export const RECENT_KEY_STORES="recentKeyStores";
+export const KEY_STORE_USING= "keyStoreOnUse";

--- a/src/containers/Common/Advanced/index.js
+++ b/src/containers/Common/Advanced/index.js
@@ -6,16 +6,16 @@ import AccountNumber from "./AccountNumber";
 import AccountIndex from "./AccountIndex";
 import Bip39PassPhrase from "./Bip39PassPhrase";
 
-const Advanced = () => {
+const Advanced = ({disableState}) => {
     const {t} = useTranslation();
     const [advanceMode, setAdvanceMode] = useState(false);
 
     const handleAccordion = () => {
-        setAdvanceMode(!advanceMode);
+        !disableState && setAdvanceMode(!advanceMode);
     };
 
     return (
-        <div className="advanced-wallet-accordion">
+        <div className={`advanced-wallet-accordion ${disableState ? "disabled" : ""}`}>
             <Card>
                 <Card.Header>
                     <p>

--- a/src/containers/Common/DashboardHeader.js
+++ b/src/containers/Common/DashboardHeader.js
@@ -53,7 +53,6 @@ const DashboardHeader = () => {
     }, []);
 
     const closeWallet = () => {
-<<<<<<< HEAD
         dispatch(userLogout());
         localStorage.removeItem("loginInfo");
         localStorage.removeItem("keplrAddress");
@@ -61,8 +60,6 @@ const DashboardHeader = () => {
         localStorage.removeItem("keyStoreOnUse");
         history.push('/');
         window.location.reload();
-=======
->>>>>>> 3fde10dc878c97867c6bc8d19f392b72a642f644
         if(loginInfo && loginInfo.loginMode==="ledger"){
             TransportWebUSB.close();
         }

--- a/src/containers/Common/DashboardHeader.js
+++ b/src/containers/Common/DashboardHeader.js
@@ -53,20 +53,15 @@ const DashboardHeader = () => {
     }, []);
 
     const closeWallet = () => {
-        dispatch(userLogout());
+        if(loginInfo && loginInfo.loginMode==="ledger"){
+            TransportWebUSB.close();
+        }
+        history.push('/');
+        window.location.reload();
         localStorage.removeItem("loginInfo");
         localStorage.removeItem("keplrAddress");
         localStorage.removeItem("encryptedMnemonic");
         localStorage.removeItem("keyStoreOnUse");
-        history.push('/');
-        window.location.reload();
-        if(loginInfo && loginInfo.loginMode==="ledger"){
-            TransportWebUSB.close();
-        }
-        
-        history.push('/');
-        window.location.reload();
-        localStorage.clear();
         dispatch(userLogout());
     };
 

--- a/src/containers/Common/DashboardHeader.js
+++ b/src/containers/Common/DashboardHeader.js
@@ -53,7 +53,10 @@ const DashboardHeader = () => {
 
     const closeWallet = () => {
         dispatch(userLogout());
-        localStorage.clear();
+        localStorage.removeItem("loginInfo");
+        localStorage.removeItem("keplrAddress");
+        localStorage.removeItem("encryptedMnemonic");
+        localStorage.removeItem("keyStoreOnUse");
         history.push('/');
         window.location.reload();
         if(loginInfo && loginInfo.loginMode==="ledger"){

--- a/src/containers/SignIn/KeyStore/ModalForm/FileInput.js
+++ b/src/containers/SignIn/KeyStore/ModalForm/FileInput.js
@@ -6,7 +6,7 @@ import {setTxKeyStore} from "../../../../store/actions/transactions/keyStore";
 import {ValidationFileTypeCheck} from "../../../../utils/validations";
 import {ENCRYPTED_MNEMONIC} from "../../../../constants/localStorage";
 
-const FileInput = () => {
+const FileInput = ({disableState}) => {
     const [fileName, setFileName] = useState('No file chosen');
     const error = useSelector((state) => state.keyStore.keyStore.error);
     const {t} = useTranslation();
@@ -28,12 +28,12 @@ const FileInput = () => {
             <p className="label"> {t("KEY_STORE_FILE")}</p>
             <div className="custom-file-section flex-fill">
                 <div>
-                    <div className="custom-file">
+                    <div className={`custom-file ${disableState?"disabled":""}`}>
                         <p className="file-button"> {t("CHOOSE_FILE")}</p>
                         <p className="file-name">{fileName}</p>
                     </div>
-                    <Form.File name="uploadFileS" onChange={onChange}
-                        className="file-upload" accept=".json" required={true}/>
+                    <Form.File name="uploadFileS" onChange={onChange} disabled={disableState}
+                        className="file-upload" accept=".json" required={!disableState}/>
                 </div>
                 <p className="input-error">{error.message}</p>
             </div>

--- a/src/containers/SignIn/KeyStore/ModalForm/RecentKeyStores.js
+++ b/src/containers/SignIn/KeyStore/ModalForm/RecentKeyStores.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import styled from 'styled-components';
+import { KEY_STORE_USING } from '../../../../constants/localStorage';
+import { setAccountIndex, setAccountNumber, setBip39Passphrase } from '../../../../store/actions/transactions/advanced';
+import { ValidateAccountIndex, ValidateBip39PassPhrase } from '../../../../utils/validations';
+
+export default function RecentKeyStores({setSelected}) {
+    const dispatch = useDispatch();
+    const [SelectedIndex, setSelectedIndex] = useState();
+
+    const RecentKeyStores = localStorage.recentKeyStores !== undefined ? JSON.parse(localStorage.recentKeyStores) : [];
+
+    function handleClick(data,index) {
+        console.log(data, index);
+        localStorage.setItem(KEY_STORE_USING, JSON.stringify(data));
+        setSelected(true);
+        setSelectedIndex(index);
+
+        dispatch(setAccountNumber({
+            value: (data.accountNumber.value),
+            error: ValidateAccountIndex(data.accountNumber.value)
+        }));
+
+        dispatch(setAccountIndex({
+            value: (data.accountIndex.value),
+            error: ValidateAccountIndex(data.accountIndex.value)
+        }));
+
+        dispatch(setBip39Passphrase({
+            value: (data.bip39PassPhrase.value),
+            error: ValidateBip39PassPhrase(data.bip39PassPhrase.value)
+        }));
+    }
+
+    return (
+        <Container className='form-field'>
+            <p className="label">Recent Keystores (Address)</p>
+            
+            {RecentKeyStores.length === 0 ? 
+                (
+                    <p className="not_found">No Recent file found</p>
+                )
+                : ""
+            }
+            <div className="recent_keystores">
+                {React.Children.toArray(RecentKeyStores.map((data, index)=>
+                    (
+                        <div key={data.address} className={`form-control recent_keystores__KeyStore ${index === SelectedIndex ? "selected": ""}`} onClick={()=>handleClick(data, index)}>
+                            <strong>{index + 1}.</strong> {data.address.substring(0, 9)}...{data.address.substring(data.address.length - 9)}
+                        </div>
+                    )
+                ))}
+            </div>
+        </Container>
+    );
+}
+
+const Container = styled.div`
+padding-bottom: 16px;
+    .recent_keystores{
+        display: flex;
+        /* flex-direction: column; */
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-evenly;
+        width: 100%;
+        overflow: hidden;
+        gap: 12px;
+        &__KeyStore{
+            display: inline-block;
+            width: min(220px, 100%);
+            background-color: transparent;
+            padding: 0 8px;
+            margin: 0;
+            height: auto;
+            cursor: pointer;
+            &.selected {
+                font-weight: 900;
+            }
+        }
+    }
+`;

--- a/src/containers/SignIn/KeyStore/ModalForm/Submit.js
+++ b/src/containers/SignIn/KeyStore/ModalForm/Submit.js
@@ -1,13 +1,15 @@
 import React from 'react';
 import Button from "../../../../components/Button";
 import {useDispatch, useSelector} from "react-redux";
-import {keyStoreSubmit} from "../../../../store/actions/signIn/keyStore";
+import {keyStoreClicked, keyStoreSubmit} from "../../../../store/actions/signIn/keyStore";
 
-const Submit = () => {
+const Submit = ({statement}) => {
     const dispatch = useDispatch();
 
     const onClick = () => {
-        dispatch(keyStoreSubmit());
+        statement ? 
+            dispatch(keyStoreClicked()) :
+            dispatch(keyStoreSubmit());
     };
 
     const accountNumber = useSelector((state) => state.advanced.accountNumber);
@@ -16,7 +18,11 @@ const Submit = () => {
     const keyStoreData = useSelector((state) => state.keyStore.keyStore);
     const password = useSelector((state) => state.keyStore.password);
 
-    const disable = (
+    const disable = statement ? (
+        password.value === '' ||
+        password.error.message !== '' || accountNumber.error.message !== '' || accountIndex.error.message !== ''
+        || bip39PassPhrase.error.message !== ''
+    ) : (
         keyStoreData.error.message !== '' || keyStoreData.value === '' || password.value === '' ||
         password.error.message !== '' || accountNumber.error.message !== '' || accountIndex.error.message !== ''
         || bip39PassPhrase.error.message !== ''

--- a/src/containers/SignIn/KeyStore/ModalForm/index.js
+++ b/src/containers/SignIn/KeyStore/ModalForm/index.js
@@ -1,5 +1,5 @@
 import {Modal as ReactModal} from 'react-bootstrap';
-import React from 'react';
+import React, { useState } from 'react';
 import {useDispatch, useSelector} from "react-redux";
 import {hideKeyStoreModal} from "../../../../store/actions/signIn/keyStore";
 import FileInput from "./FileInput";
@@ -9,6 +9,7 @@ import Icon from "../../../../components/Icon";
 import Advanced from "../../../Common/Advanced";
 import {useTranslation} from "react-i18next";
 import {hideSignInModal, showSignInModal} from "../../../../store/actions/signIn/modal";
+import RecentKeyStores from './RecentKeyStores';
 
 const ModalForm = () => {
     const {t} = useTranslation();
@@ -16,6 +17,8 @@ const ModalForm = () => {
     const response = useSelector((state) => state.signInKeyStore.response);
 
     const dispatch = useDispatch();
+
+    const [RecentSelected, setRecentSelected] = useState(false);
 
     const handleClose = () => {
         dispatch(hideSignInModal());
@@ -25,6 +28,7 @@ const ModalForm = () => {
     const keyStorePrevious = () => {
         dispatch(hideKeyStoreModal());
         dispatch(showSignInModal());
+        setRecentSelected(false);
     };
 
     return (
@@ -47,10 +51,11 @@ const ModalForm = () => {
                 <p>{t("LOGIN_WITH_KEYSTORE")}</p>
             </ReactModal.Header>
             <ReactModal.Body className="create-wallet-body import-wallet-body">
-                <FileInput/>
+                <RecentKeyStores setSelected={setRecentSelected}/>
+                <FileInput disableState={RecentSelected}/>
                 <Password/>
-                <Advanced/>
-                <Submit/>
+                <Advanced disableState={RecentSelected}/>
+                <Submit statement={RecentSelected}/>
                 {response.error.message !== "" ?
                     <div className="login-error"><p className="error-response">{response.error.message}</p></div>
                     : ""

--- a/src/utils/ledger.js
+++ b/src/utils/ledger.js
@@ -31,7 +31,10 @@ export const ledgerDisconnect = async (dispatch, history) =>{
             alert("ledger disconnected please login again");
             history.push('/');
             dispatch(userLogout());
-            localStorage.clear();
+            localStorage.removeItem("loginInfo");
+            localStorage.removeItem("keplrAddress");
+            localStorage.removeItem("encryptedMnemonic");
+            localStorage.removeItem("keyStoreOnUse");
             window.location.reload();
 
         });


### PR DESCRIPTION
## 1. Overview

added functionality to login from up to 4 recent used KeyStors configuration

## 2. Implementation details

_How is the feature/bug fix implemented (highlights only) as well as important
design rationales_

- Removed clearing local storage every time but only the variables necessary.
- storing recent used keystores in the local storage variable
- reading the data from local storage and with a on click function

## 3. How to test/use

_How can people test/use this_

- Try logging in with keyStores any amount of time (You should see only 4)
- Try login using recent keystore files option

## 4. Limitations (optional)

_Limitation of the capabilities described in the Overview section, if
applicable_

-
-

## 5. Future Work (optional)

_Potential follow up work, if applicable_

-
-

